### PR TITLE
Add cast to tuple in merge node

### DIFF
--- a/brewery/nodes/record_nodes.py
+++ b/brewery/nodes/record_nodes.py
@@ -340,7 +340,7 @@ class MergeNode(Node):
                     break
                 else:
                     joined = True
-                    joined_row += detail
+                    joined_row += tuple(detail)
 
             if joined:
                 self.put(joined_row)


### PR DESCRIPTION
In merge node raise this exception becouse "detail" is a rowproxy:
brewery.common.StreamRuntimeError: stream failed. reason: 
exception: TypeError: 
node: <brewery.nodes.record_nodes.MergeNode object at 0xa76790c>
can only concatenate tuple (not "list") to tuple
traceback
  File "/usr/local/lib/python2.7/dist-packages/brewery-0.8.0-py2.7.egg/brewery/streams.py", line 533, in run
    self.node.run()
  File "/usr/local/lib/python2.7/dist-packages/brewery-0.8.0-py2.7.egg/brewery/nodes/record_nodes.py", line 344, in run
    joined_row += detail
